### PR TITLE
Fix: Handle concurrent attacks with an action queue

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,18 +1,24 @@
-import sys
-import os
-import threading
-from pynput import keyboard
+"""
+Pixel Slayer: A simple desktop pet game where a warrior battles monsters.
+"""
 
-from PyQt6.QtWidgets import QApplication, QWidget, QLabel, QVBoxLayout
-from PyQt6.QtGui import QPixmap, QMouseEvent, QMovie
-from PyQt6.QtCore import Qt, QPoint, pyqtSignal, QObject, QTimer
+import sys
+import threading
+from collections import deque
+from pathlib import Path
+from typing import Deque, Dict, Optional
+
+from pynput import keyboard
+from PyQt6.QtCore import (QObject, QPoint, Qt, QTimer, pyqtSignal)
+from PyQt6.QtGui import QMouseEvent, QMovie, QPixmap
+from PyQt6.QtWidgets import QApplication, QLabel, QVBoxLayout, QWidget
 
 # --- Constants ---
-LEVEL_2_THRESHOLD = 50
-ASSET_DIR = "assets"
+LEVEL_2_THRESHOLD: int = 50
+ASSET_DIR: Path = Path("assets")
 
 # --- Sprite Definitions ---
-SPRITES = {
+SPRITES: Dict[str, Dict[int, Dict[str, str]]] = {
     "character": {
         1: {"idle": "warrior_lv1_idle.png", "attack": "warrior_lv1_attack.png"},
         2: {"idle": "warrior_lv2_idle.png", "attack": "warrior_lv2_attack.png"},
@@ -20,49 +26,76 @@ SPRITES = {
     "monster": {
         1: {"idle": "monster_lv1_idle.png", "hurt": "monster_lv1_hurt.png"},
         2: {"idle": "monster_lv2_idle.png", "hurt": "monster_lv2_hurt.png"},
-    }
+    },
 }
 
+
 class GameLogic(QObject):
-    """Handles the game's logic, such as attack counts and level progression."""
-    level_changed = pyqtSignal(int)
-    attack_count_changed = pyqtSignal(int)
+    """Handles the game's logic, such as attack counts and level progression.
 
-    def __init__(self):
+    Attributes:
+        level_changed (pyqtSignal): Signal emitted when the character's level changes.
+        attack_count_changed (pyqtSignal): Signal emitted when the attack count changes.
+    """
+
+    level_changed: pyqtSignal = pyqtSignal(int)
+    attack_count_changed: pyqtSignal = pyqtSignal(int)
+
+    def __init__(self) -> None:
+        """Initializes the GameLogic."""
         super().__init__()
-        self.attack_count = 0
-        self.current_level = 1
+        self.attack_count: int = 0
+        self.current_level: int = 1
 
-    def increment_attack(self):
+    def increment_attack(self) -> None:
+        """Increments the attack count and checks for level evolution."""
         self.attack_count += 1
         self.attack_count_changed.emit(self.attack_count)
         if self.current_level == 1 and self.attack_count >= LEVEL_2_THRESHOLD:
             self.evolve()
 
-    def evolve(self):
+    def evolve(self) -> None:
+        """Evolves the character to the next level."""
         self.current_level = 2
         self.level_changed.emit(self.current_level)
 
+
 class PixelSlayerWidget(QWidget):
-    """Main application widget."""
-    def __init__(self, comm, game_logic):
+    """Main application widget that displays the game characters.
+
+    This widget manages the UI, character sprites, and user interactions.
+    """
+
+    def __init__(self, comm: "Communicate", game_logic: GameLogic) -> None:
+        """Initializes the PixelSlayerWidget.
+
+        Args:
+            comm (Communicate): The communication object for key presses.
+            game_logic (GameLogic): The game logic handler.
+        """
         super().__init__()
-        self.comm = comm
-        self.game_logic = game_logic
-        self.pixmaps = {}
-        self.movies = {}
-        self.old_pos = QPoint()
+        self.comm: "Communicate" = comm
+        self.game_logic: GameLogic = game_logic
+        self.pixmaps: Dict[str, Dict[int, Dict[str, QPixmap]]] = {}
+        self.movies: Dict[str, Dict[int, Dict[str, QMovie]]] = {}
+        self.old_pos: QPoint = QPoint()
+        self.action_queue: Deque[str] = deque()
+        self.is_processing_action: bool = False
 
         self.load_assets()
         self.init_ui()
 
         # --- Connect signals ---
-        self.comm.key_pressed.connect(self.handle_attack)
+        self.comm.key_pressed.connect(self.queue_attack)
         self.game_logic.level_changed.connect(self.on_level_changed)
         self.game_logic.attack_count_changed.connect(self.on_attack_count_changed)
 
+        # --- Timer for processing the action queue ---
+        self.queue_timer: QTimer = QTimer(self)
+        self.queue_timer.timeout.connect(self.process_action_queue)
+        self.queue_timer.start(50)  # Check the queue every 50ms
 
-    def load_assets(self):
+    def load_assets(self) -> None:
         """Pre-loads all necessary sprites (images and GIFs)."""
         for category, levels in SPRITES.items():
             self.pixmaps[category] = {}
@@ -71,36 +104,37 @@ class PixelSlayerWidget(QWidget):
                 self.pixmaps[category][level] = {}
                 self.movies[category][level] = {}
                 for state, filename in states.items():
-                    path = os.path.join(ASSET_DIR, filename)
-                    if not os.path.exists(path):
+                    path: Path = ASSET_DIR / filename
+                    if not path.exists():
                         print(f"Error: Asset not found at {path}")
-                        sys.exit(1) # Exit if essential asset is missing
+                        sys.exit(1)  # Exit if essential asset is missing
 
-                    if filename.endswith(".gif"):
-                        movie = QMovie(path)
+                    if path.suffix == ".gif":
+                        movie = QMovie(str(path))
                         self.movies[category][level][state] = movie
                     else:
-                        pixmap = QPixmap(path)
+                        pixmap = QPixmap(str(path))
                         self.pixmaps[category][level][state] = pixmap
 
-
-    def init_ui(self):
+    def init_ui(self) -> None:
         """Initializes the user interface."""
         self.setWindowFlags(
-            Qt.WindowType.FramelessWindowHint |
-            Qt.WindowType.WindowStaysOnTopHint |
-            Qt.WindowType.Tool
+            Qt.WindowType.FramelessWindowHint
+            | Qt.WindowType.WindowStaysOnTopHint
+            | Qt.WindowType.Tool
         )
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
         self.setGeometry(100, 100, 200, 150)
 
-        self.layout = QVBoxLayout()
+        self.layout: QVBoxLayout = QVBoxLayout()
         self.setLayout(self.layout)
 
-        self.character_label = QLabel(self)
-        self.monster_label = QLabel(self)
-        self.counter_label = QLabel("Attacks: 0", self)
-        self.counter_label.setStyleSheet("color: white; font-weight: bold; background-color: rgba(0,0,0,150); padding: 2px;")
+        self.character_label: QLabel = QLabel(self)
+        self.monster_label: QLabel = QLabel(self)
+        self.counter_label: QLabel = QLabel("Attacks: 0", self)
+        self.counter_label.setStyleSheet(
+            "color: white; font-weight: bold; background-color: rgba(0,0,0,150); padding: 2px;"
+        )
         self.counter_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         self.layout.addWidget(self.monster_label)
@@ -110,73 +144,137 @@ class PixelSlayerWidget(QWidget):
         self.reset_sprites()
         self.show()
 
-    def set_sprite(self, label, category, level, state):
-        """Sets the appropriate pixmap or movie on a label."""
+    def set_sprite(self, label: QLabel, category: str, level: int, state: str) -> None:
+        """Sets the appropriate pixmap or movie on a label.
+
+        Args:
+            label (QLabel): The label to set the sprite on.
+            category (str): The category of the sprite (e.g., "character").
+            level (int): The current level of the sprite.
+            state (str): The state of the sprite (e.g., "idle", "attack").
+        """
         if state in self.movies[category][level]:
-            label.setMovie(self.movies[category][level][state])
-            self.movies[category][level][state].start()
+            movie = self.movies[category][level][state]
+            label.setMovie(movie)
+            movie.start()
         elif state in self.pixmaps[category][level]:
             label.setPixmap(self.pixmaps[category][level][state])
 
+    def queue_attack(self) -> None:
+        """Adds an 'attack' action to the queue."""
+        self.action_queue.append("attack")
 
-    def handle_attack(self):
-        """Handles the attack logic."""
+    def process_action_queue(self) -> None:
+        """Processes one action from the queue if not already processing."""
+        if not self.is_processing_action and self.action_queue:
+            action = self.action_queue.popleft()
+            if action == "attack":
+                self.execute_attack()
+
+    def execute_attack(self) -> None:
+        """Handles the attack logic and animation."""
+        self.is_processing_action = True
         self.game_logic.increment_attack()
-        self.set_sprite(self.character_label, "character", self.game_logic.current_level, "attack")
-        self.set_sprite(self.monster_label, "monster", self.game_logic.current_level, "hurt")
+        self.set_sprite(
+            self.character_label, "character", self.game_logic.current_level, "attack"
+        )
+        self.set_sprite(
+            self.monster_label, "monster", self.game_logic.current_level, "hurt"
+        )
         QTimer.singleShot(150, self.reset_sprites)
 
+    def reset_sprites(self) -> None:
+        """Resets sprites to their idle state and allows the next action."""
+        self.set_sprite(
+            self.character_label, "character", self.game_logic.current_level, "idle"
+        )
+        self.set_sprite(
+            self.monster_label, "monster", self.game_logic.current_level, "idle"
+        )
+        self.is_processing_action = False
 
-    def reset_sprites(self):
-        """Resets sprites to their idle state."""
-        self.set_sprite(self.character_label, "character", self.game_logic.current_level, "idle")
-        self.set_sprite(self.monster_label, "monster", self.game_logic.current_level, "idle")
+    def on_level_changed(self, level: int) -> None:
+        """Updates UI when the level changes.
 
-    def on_level_changed(self, level):
-        """Updates UI when the level changes."""
+        Args:
+            level (int): The new level.
+        """
         print(f"EVOLVED to Level {level}!")
         self.reset_sprites()
         self.counter_label.setText(f"EVOLVED! Attacks: {self.game_logic.attack_count}")
-        self.counter_label.setStyleSheet("color: yellow; font-weight: bold; background-color: rgba(0,100,0,200); padding: 2px;")
+        self.counter_label.setStyleSheet(
+            "color: yellow; font-weight: bold; background-color: rgba(0,100,0,200); padding: 2px;"
+        )
 
-    def on_attack_count_changed(self, count):
-        """Updates the counter label."""
+    def on_attack_count_changed(self, count: int) -> None:
+        """Updates the counter label.
+
+        Args:
+            count (int): The new attack count.
+        """
         if self.game_logic.current_level == 1:
             self.counter_label.setText(f"Attacks: {count}")
 
-    def mousePressEvent(self, event: QMouseEvent):
+    def mousePressEvent(self, event: QMouseEvent) -> None:
+        """Handles mouse press events for window dragging.
+
+        Args:
+            event (QMouseEvent): The mouse event.
+        """
         if event.button() == Qt.MouseButton.LeftButton:
             self.old_pos = event.globalPosition().toPoint()
 
-    def mouseMoveEvent(self, event: QMouseEvent):
+    def mouseMoveEvent(self, event: QMouseEvent) -> None:
+        """Handles mouse move events for window dragging.
+
+        Args:
+            event (QMouseEvent): The mouse event.
+        """
         if event.buttons() == Qt.MouseButton.LeftButton:
-            delta = QPoint(event.globalPosition().toPoint() - self.old_pos)
+            delta = event.globalPosition().toPoint() - self.old_pos
             self.move(self.x() + delta.x(), self.y() + delta.y())
             self.old_pos = event.globalPosition().toPoint()
 
 
 class Communicate(QObject):
-    """Communicates between the keyboard listener and the GUI thread."""
-    key_pressed = pyqtSignal()
+    """Communicates between the keyboard listener and the GUI thread.
 
-def key_listener_thread(comm: Communicate):
-    """Listens for global key presses in a separate thread."""
-    def on_press(key):
+    Attributes:
+        key_pressed (pyqtSignal): Signal emitted when a key is pressed.
+    """
+
+    key_pressed: pyqtSignal = pyqtSignal()
+
+
+def key_listener_thread(comm: Communicate) -> None:
+    """Listens for global key presses in a separate thread.
+
+    Args:
+        comm (Communicate): The communication object to signal key presses.
+    """
+
+    def on_press(key: Optional[keyboard.Key | keyboard.KeyCode]) -> None:
+        """Callback function for key presses."""
         comm.key_pressed.emit()
 
     with keyboard.Listener(on_press=on_press) as listener:
         listener.join()
 
-def main():
+
+def main() -> None:
+    """Main function to run the application."""
     app = QApplication(sys.argv)
     comm = Communicate()
     game_logic = GameLogic()
-    widget = PixelSlayerWidget(comm, game_logic)
+    _ = PixelSlayerWidget(comm, game_logic)
 
-    listener = threading.Thread(target=key_listener_thread, args=(comm,), daemon=True)
+    listener = threading.Thread(
+        target=key_listener_thread, args=(comm,), daemon=True
+    )
     listener.start()
 
     sys.exit(app.exec())
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Sửa lỗi game bị treo khi người chơi và quái vật tấn công cùng lúc bằng cách giới thiệu một hàng đợi hành động (action queue).

- Các hành động tấn công của người chơi được thêm vào một `deque`.
- Một `QTimer` xử lý các hành động trong hàng đợi một cách tuần tự, đảm bảo mỗi hành động hoàn thành trước khi bắt đầu hành động tiếp theo.
- Thêm biến `is_processing_action` để ngăn chặn các hành động chồng chéo.
- Cập nhật code để tuân thủ các tiêu chuẩn của dự án, bao gồm việc sử dụng `pathlib`, thêm type hints và docstrings.

Closes #1
